### PR TITLE
fix: should not reset `instance`

### DIFF
--- a/src/createBaseForm.jsx
+++ b/src/createBaseForm.jsx
@@ -460,7 +460,7 @@ function createBaseForm(option = {}, mixins = []) {
           const field = fields[name];
           if (field && 'value' in field) {
             changed = true;
-            newFields[name] = {};
+            newFields[name] = { instance: field.instance };
           }
         });
         if (changed) {


### PR DESCRIPTION
`instance` 应该视为常量，用户无法修改，也不该 reset，不然 `validateFieldsAndScroll` 就无法用了。