### PR TITLE
fix: should not reset instance

### DIFF
--- a/src/createBaseForm.jsx
+++ b/src/createBaseForm.jsx
@@ -268,6 +268,11 @@ function createBaseForm(option = {}, mixins = []) {
       },
       setFields(fields) {
         const originalFields = this.fields;
+        // reserve `instance`
+        Object.keys(fields).forEach((key) => {
+          fields[key].instance = originalFields[key].instance;
+        });
+
         const nowFields = {
           ...originalFields,
           ...fields,
@@ -521,9 +526,7 @@ function createBaseForm(option = {}, mixins = []) {
           const field = fields[name];
           if (field && 'value' in field) {
             changed = true;
-            newFields[name] = {
-              instance: field.instance,
-            };
+            newFields[name] = {};
           }
         });
         if (changed) {


### PR DESCRIPTION
之前只是在 `resetFields` 中保证不会重置 `instance`，但其实 `setFieldsValue` 也会重置 `instance`，所以现在直接在 `setFields` 中处理。