### PR TITLE
feat: getFormControl

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,27 @@ createForm() will return another function:
 
 Will pass a object as prop form with the following members to WrappedComponent:
 
+### getFormControl(fieldElem: ReactNode, option: Object): ReactNode
+
+Similar to `getFieldProps`:
+
+```jsx
+<form>
+  {getFormControl(<input />, { name: 'name', ...otherOptions })}
+</form>
+```
+
 ### getFieldProps(name, option): Object
 
 Will create props which can be set on a input/InputComponent which support value and onChange interface.
 
 After set, this will create a binding with this input.
+
+```jsx
+<form>
+  <input {...getFieldProps('name', { ...options })} />
+</form>
+```
 
 #### name: String
 

--- a/README.md
+++ b/README.md
@@ -103,13 +103,13 @@ createForm() will return another function:
 
 Will pass a object as prop form with the following members to WrappedComponent:
 
-### getFormControl(fieldElem: ReactNode, option: Object): ReactNode
+### getFormControl(option: Object, fieldElem: ReactNode): ReactNode
 
-Similar to `getFieldProps`:
+Similar to `getFieldProps`, but `option.name` is required:
 
 ```jsx
 <form>
-  {getFormControl(<input />, { name: 'name', ...otherOptions })}
+  {getFormControl({ name: 'name', ...otherOptions }, <input />)}
 </form>
 ```
 

--- a/examples/getFormControl.html
+++ b/examples/getFormControl.html
@@ -1,0 +1,1 @@
+placeholder

--- a/examples/getFormControl.js
+++ b/examples/getFormControl.js
@@ -23,14 +23,18 @@ class Form extends React.Component {
 
     return (
       <form onSubmit={this.onSubmit}>
-        {getFormControl(<input onChange={console.log.bind(console)} />, {
+        {getFormControl({
           name: 'name',
           initialValue: '',
           rules: [{
             required: true,
             message: 'What\'s your name?',
           }],
-        })}
+        },
+          <input
+            onChange={console.log.bind(console)}
+          />
+        )}
         <div style={{ color: 'red' }}>
           {(getFieldError('name') || []).join(', ')}
         </div>

--- a/examples/getFormControl.js
+++ b/examples/getFormControl.js
@@ -1,0 +1,44 @@
+/* eslint react/no-multi-comp:0, no-console:0 */
+
+import React, { PropTypes } from 'react';
+import ReactDOM from 'react-dom';
+import { createForm } from 'rc-form';
+
+class Form extends React.Component {
+  static propTypes = {
+    form: PropTypes.object,
+  }
+  onSubmit = (e) => {
+    e.preventDefault();
+    this.props.form.validateFields((error, values) => {
+      if (!error) {
+        console.log('ok', values);
+      } else {
+        console.log('error', error, values);
+      }
+    });
+  }
+  render() {
+    const { getFormControl, getFieldError } = this.props.form;
+
+    return (
+      <form onSubmit={this.onSubmit}>
+        {getFormControl(<input onChange={console.log.bind(console)} />, {
+          name: 'name',
+          initialValue: '',
+          rules: [{
+            required: true,
+            message: 'What\'s your name?',
+          }],
+        })}
+        <div style={{ color: 'red' }}>
+          {(getFieldError('name') || []).join(', ')}
+        </div>
+        <button>Submit</button>
+      </form>
+    );
+  }
+}
+
+const WrappedForm = createForm()(Form);
+ReactDOM.render(<WrappedForm />, document.getElementById('__react-content'));

--- a/src/createBaseForm.js
+++ b/src/createBaseForm.js
@@ -115,7 +115,7 @@ function createBaseForm(option = {}, mixins = []) {
         };
       },
 
-      getFormControl(fieldElem, fieldOption = {}) {
+      getFormControl(fieldOption = {}, fieldElem) {
         if (process.env.NODE_ENV !== 'production') {
           const valuePropName = fieldOption.valuePropName || 'value';
           if (valuePropName in fieldElem.props) {

--- a/src/createBaseForm.js
+++ b/src/createBaseForm.js
@@ -115,9 +115,41 @@ function createBaseForm(option = {}, mixins = []) {
         };
       },
 
+      getFormControl(fieldElem, fieldOption = {}) {
+        if (process.env.NODE_ENV !== 'production') {
+          const valuePropName = fieldOption.valuePropName || 'value';
+          if (valuePropName in fieldElem.props) {
+            throw new Error(
+              `\`getFormControl\` will override \`${valuePropName}\`, ` +
+                `so please don't set \`${valuePropName}\` directly ` +
+                `and use \`setFieldsValue\` to set it.`
+            );
+          }
+          const defaultValuePropName =
+                  `default${valuePropName[0].toUpperCase()}${valuePropName.slice(1)}`;
+          if (defaultValuePropName in fieldElem.props) {
+            throw new Error(
+              `\`${defaultValuePropName}\` is invalid ` +
+                `for \`getFormControl\` will set \`${valuePropName}\`,` +
+                ` please use \`option.initialValue\` instead.`
+            );
+          }
+        }
+
+        const { name, ...restOptions } = fieldOption;
+        const trigger = fieldOption.trigger || defaultTrigger;
+        const validateTrigger = fieldOption.validateTrigger || defaultValidateTrigger;
+        restOptions[trigger] = fieldElem.props[trigger];
+        restOptions[validateTrigger] = fieldElem.props[validateTrigger];
+
+        return React.cloneElement(fieldElem, this.getFieldProps(name, restOptions));
+      },
+
       getFieldProps(name, fieldOption = {}) {
-        if (!name) {
-          throw new Error('must call getFieldProps with valid name string!');
+        if (process.env.NODE_ENV !== 'production') {
+          if (!name) {
+            throw new Error('Must call `getFieldProps` with valid name string!');
+          }
         }
 
         const {

--- a/src/createForm.js
+++ b/src/createForm.js
@@ -9,6 +9,7 @@ export const mixin = {
       setFieldsValue: this.setFieldsValue,
       setFields: this.setFields,
       setFieldsInitialValue: this.setFieldsInitialValue,
+      getFormControl: this.getFormControl,
       getFieldProps: this.getFieldProps,
       getFieldError: this.getFieldError,
       isFieldValidating: this.isFieldValidating,


### PR DESCRIPTION
ref: https://github.com/ant-design/ant-design/issues/1533

与 `getFieldProps` 相比，`getFormControl` 会多做点事：

* 判断是否设置了 `value` `defaultValue` 之类会与 rc-form 的工作机制发生冲突的属性，然后报错
* 自动处理用户定义的事件（`onChange` 之类）与 trigger 的冲突