### PR TITLE
pass all fields value into onFieldsChange method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ build
 dist
 lib
 coverage
+.vscode

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ preset messages of [async-validator](https://github.com/yiminghe/async-validator
 
 Get new props transfered to WrappedComponent. Defaults to props=>props.
 
-### formOption.onFieldsChange(props, fields)
+### formOption.onFieldsChange(props, fields, allFieldsValue)
 
 Called when field changed, you can dispatch fields to redux store.
 

--- a/src/createBaseForm.js
+++ b/src/createBaseForm.js
@@ -384,7 +384,7 @@ function createBaseForm(option = {}, mixins = []) {
           changedFieldsName.forEach((f) => {
             changedFields[f] = this.getField(f);
           });
-          onFieldsChange(this.props, changedFields);
+          onFieldsChange(this.props, changedFields, this.getFieldsValue());
         }
         this.forceUpdate();
       },

--- a/tests/map.spec.js
+++ b/tests/map.spec.js
@@ -42,8 +42,8 @@ describe('map usage', () => {
         const field = fields.normal;
         expect(field.name).to.be('normal');
         expect(field.value).to.be('3');
-        expect(allFields['normal']).to.be('3');
-        expect(allFields['normal2']).to.be(undefined);
+        expect(allFields.normal).to.be('3');
+        expect(allFields.normal2).to.be(undefined);
       },
       mapPropsToFields(props) {
         return {

--- a/tests/map.spec.js
+++ b/tests/map.spec.js
@@ -37,11 +37,13 @@ describe('map usage', () => {
   it('onFieldsChange works', () => {
     const Test = createForm({
       withRef: true,
-      onFieldsChange(props, fields) {
+      onFieldsChange(props, fields, allFields) {
         expect(Object.keys(fields).length).to.be(1);
         const field = fields.normal;
         expect(field.name).to.be('normal');
         expect(field.value).to.be('3');
+        expect(allFields['normal']).to.be('3');
+        expect(allFields['normal2']).to.be(undefined);
       },
       mapPropsToFields(props) {
         return {


### PR DESCRIPTION
Sometimes I want to do something when one field changing but use another field's value. So I make this PR.

We can use onChange prop at <input> most of the time. But when we use package like Antd, there is no way to use a custom onChange prop（the onChange is generated by getFieldDecorator()）.

Or we can add an option for getFieldDecorator() to do this? Or there is another solution I do not know? Please discuss.