### PR TITLE
allow for infinite field nesting on return object

### DIFF
--- a/src/createBaseForm.js
+++ b/src/createBaseForm.js
@@ -6,6 +6,7 @@ import {
   isEmptyObject, flattenArray,
   getNameKeyObj, getNameKeyStr,
   flatFieldNames, clearVirtualField,
+  setObject,
 } from './utils';
 import AsyncValidator from 'async-validator';
 import warning from 'warning';
@@ -333,8 +334,7 @@ function createBaseForm(option = {}, mixins = []) {
             if (fieldsMeta.hasOwnProperty(fieldKey)) {
               const nameKeyObj = getNameKeyObj(fieldKey);
               if (nameKeyObj.name === name && nameKeyObj.key) {
-                ret[nameKeyObj.key] =
-                  this.getValueFromFieldsInternal(fieldKey, fields);
+                setObject(nameKeyObj.key, this.getValueFromFieldsInternal(fieldKey, fields), ret)
               }
             }
           }

--- a/src/createBaseForm.js
+++ b/src/createBaseForm.js
@@ -334,7 +334,7 @@ function createBaseForm(option = {}, mixins = []) {
             if (fieldsMeta.hasOwnProperty(fieldKey)) {
               const nameKeyObj = getNameKeyObj(fieldKey);
               if (nameKeyObj.name === name && nameKeyObj.key) {
-                setObject(nameKeyObj.key, this.getValueFromFieldsInternal(fieldKey, fields), ret)
+                setObject(nameKeyObj.key, this.getValueFromFieldsInternal(fieldKey, fields), ret);
               }
             }
           }

--- a/src/utils.js
+++ b/src/utils.js
@@ -110,6 +110,16 @@ export function getNameKeyObj(str) {
   };
 }
 
+export function setObject(str, value, context) {
+  var parts = str.split(NAME_KEY_SEP),
+  p = parts.pop();
+  // if object && string has another part && we've looped less than 100 times
+  for(var i=0, j; context && (j=parts[i]) && i<100; i++){
+    context = (j in context ? context[j] : context[j]={});
+  }
+  return context && p ? (context[p]=value) : undefined; // Object
+}
+
 export function flatFields(fields_, fieldsMeta) {
   const fields = { ...fields_ };
   Object.keys(fields).forEach((k) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -111,13 +111,19 @@ export function getNameKeyObj(str) {
 }
 
 export function setObject(str, value, context) {
-  var parts = str.split(NAME_KEY_SEP),
-  p = parts.pop();
+  const parts = str.split(NAME_KEY_SEP);
+  const p = parts.pop();
+  let i;
+  let j;
+
   // if object && string has another part && we've looped less than 100 times
-  for(var i=0, j; context && (j=parts[i]) && i<100; i++){
-    context = (j in context ? context[j] : context[j]={});
+  if (parts[i]) {
+    j = parts[i];
+    for (i = 0; context && i < 100; i++) {
+      context = (j in context ? context[j] : context[j] = {});
+    }
   }
-  return context && p ? (context[p]=value) : undefined; // Object
+  return context && p ? (context[p] = value) : undefined; // Object
 }
 
 export function flatFields(fields_, fieldsMeta) {


### PR DESCRIPTION
Initially, when looking through the issues that were allowing nesting of fields, I had found [this issue](https://github.com/react-component/form/pull/21) that allowed for something along the lines of 

     {...getFieldProps('normal.a', {
       valuePropName: 'checked',
     })}

However, I had expected to be able to also do ```'normal.a.b.c'``` and have that object returned. Apparently that is not the case. This remedies this, with a hard limit of 100 levels deep on an object. 