### PR TITLE
feat: add onValuesChange, close: #52

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,13 @@ preset messages of [async-validator](https://github.com/yiminghe/async-validator
 
 Get new props transfered to WrappedComponent. Defaults to props=>props.
 
-### formOption.onFieldsChange(props, fields)
+### formOption.onFieldsChange(props, changedFields)
 
 Called when field changed, you can dispatch fields to redux store.
+
+### formOption.onValuesChange(props, changedValues)
+
+Called when value changed.
 
 ### formOption.mapPropsToFields(props)
 

--- a/examples/nested-field.js
+++ b/examples/nested-field.js
@@ -176,7 +176,14 @@ let Form = React.createClass({
   },
 });
 
-Form = createForm()(Form);
+Form = createForm({
+  onFieldsChange(_, changedFields) {
+    console.log('onFieldsChange: ', changedFields);
+  },
+  onValuesChange(_, changedValues) {
+    console.log('onValuesChange: ', changedValues);
+  },
+})(Form);
 
 class App extends React.Component {
   render() {

--- a/tests/onValuesChange.spec.js
+++ b/tests/onValuesChange.spec.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import expect from 'expect.js';
+import { Simulate } from 'react-addons-test-utils';
+import { createForm } from '../';
+
+const TestComponent = React.createClass({
+  propTypes: {
+    form: React.PropTypes.object,
+  },
+  render() {
+    const { getFieldProps } = this.props.form;
+    return <input {...getFieldProps('employee.name', { initialValue: '' })} />;
+  },
+});
+
+describe('onValuesChange', () => {
+  let container;
+  let component;
+  let form;
+  let values;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    const Test = createForm({
+      withRef: true,
+      onValuesChange(props, changedValues) {
+        values = changedValues;
+      },
+    })(TestComponent);
+    component = ReactDOM.render(<Test />, container);
+    component = component.refs.wrappedComponent;
+    form = component.props.form;
+  });
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(container);
+    document.body.removeChild(container);
+    values = undefined;
+  });
+
+  it('should trigger `onValuesChange` when value change', () => {
+    Simulate.change(form.getFieldInstance('employee.name'), { target: { value: 'Benjy' } });
+    expect(values).to.be.eql({ employee: { name: 'Benjy' } });
+  });
+
+  it('should trigger `onValuesChange` when `setFieldsValue`', () => {
+    form.setFieldsValue({ employee: { name: 'Benjy' } });
+    expect(values).to.be.eql({ employee: { name: 'Benjy' } });
+  });
+});


### PR DESCRIPTION
close: #52

`onValuesChange` 比 `onFieldsChange` 更加轻量级，并且也符合大部分开发者的直觉。