### PR TITLE
Fix nested fields breaks the validateAndScroll function

### DIFF
--- a/src/createBaseForm.js
+++ b/src/createBaseForm.js
@@ -452,7 +452,7 @@ function createBaseForm(option = {}, mixins = []) {
           const name = field.name;
           if (options.force !== true && field.dirty === false) {
             if (field.errors) {
-              set(alreadyErrors, name, { errors: field.errors });
+              alreadyErrors[name] = { errors: field.errors };
             }
             return;
           }


### PR DESCRIPTION
lodash.set creates a nested error object, therefore `validateFieldsAndScroll` can not get the field instance by name, this causes the scroll doesn't work with nested fields.

For details
https://github.com/ant-design/ant-design/issues/5410