### PR TITLE
Issues/94 add full data argument on fields change and on values change

### DIFF
--- a/examples/nested-field.js
+++ b/examples/nested-field.js
@@ -178,11 +178,11 @@ class Form extends React.Component {
 }
 
 Form = createForm({
-  onFieldsChange(_, changedFields) {
-    console.log('onFieldsChange: ', changedFields);
+  onFieldsChange(_, changedFields, allFields) {
+    console.log('onFieldsChange: ', changedFields, allFields);
   },
-  onValuesChange(_, changedValues) {
-    console.log('onValuesChange: ', changedValues);
+  onValuesChange(_, changedValues, allValues) {
+    console.log('onValuesChange: ', changedValues, allValues);
   },
 })(Form);
 

--- a/src/createBaseForm.js
+++ b/src/createBaseForm.js
@@ -78,7 +78,15 @@ function createBaseForm(option = {}, mixins = []) {
           fieldMeta.getValueFromEvent(...args) :
           getValueFromEvent(...args);
         if (onValuesChange && value !== this.fieldsStore.getFieldValue(name)) {
-          onValuesChange(this.props, set({}, name, value));
+          const valuesAll = this.fieldsStore.getValueFromFieldsAll();
+          let valuesAllSet = {};
+          valuesAll[name] = value;
+          Object.keys(valuesAll).forEach(key => {
+            if (valuesAll[key]) {
+              valuesAllSet = set(valuesAllSet, key, valuesAll[key]);
+            }
+          });
+          onValuesChange(this.props, set({}, name, value), valuesAllSet);
         }
         const nameKeyObj = getNameIfNested(name);
         if (this.fieldsStore.getFieldMeta(nameKeyObj.name).exclusive) {
@@ -245,7 +253,7 @@ function createBaseForm(option = {}, mixins = []) {
           Object.keys(fields).forEach((f) => {
             changedFields[f] = this.fieldsStore.getField(f);
           });
-          onFieldsChange(this.props, changedFields);
+          onFieldsChange(this.props, changedFields, this.fieldsStore.getFieldAll());
         }
         this.forceUpdate();
       },

--- a/src/createFieldsStore.js
+++ b/src/createFieldsStore.js
@@ -49,6 +49,14 @@ class FieldsStore {
     });
     this.fields = nowFields;
   }
+  getUndirtyFields() {
+    const undirtyFields = {};
+    const undirtyValues = Object.keys(this.fieldsMeta).filter(key =>
+      !this.fields[key] && this.fieldsMeta[key].initialValue)
+      .map(key => ({ dirty: false, name: key, value: this.fieldsMeta[key].initialValue }));
+    undirtyValues.forEach(value => undirtyFields[value.name] = value);
+    return undirtyFields;
+  }
   resetFields(ns) {
     const newFields = {};
     const { fields } = this;
@@ -61,7 +69,6 @@ class FieldsStore {
     });
     return newFields;
   }
-
   getValueFromFieldsInternal(name, fields) {
     const field = fields[name];
     if (field && 'value' in field) {
@@ -83,6 +90,16 @@ class FieldsStore {
       return ret[name];
     }
     return this.getValueFromFieldsInternal(name, fields);
+  }
+  getValueFromFieldsAll = () => {
+    const { fieldsMeta, fields } = this;
+    const ret = {};
+    let fieldKeyValue;
+    Object.keys(fieldsMeta).forEach(fieldKey => {
+      fieldKeyValue = this.getValueFromFieldsInternal(fieldKey, fields);
+      ret[fieldKey] = fieldKeyValue;
+    });
+    return ret;
   }
 
   getValidFieldsName() {
@@ -115,6 +132,9 @@ class FieldsStore {
       ...this.fields[name],
       name,
     };
+  }
+  getFieldAll() {
+    return Object.assign({}, this.fields, this.getUndirtyFields());
   }
   getFieldMember(name, member) {
     return this.getField(name)[member];

--- a/tests/map.spec.js
+++ b/tests/map.spec.js
@@ -31,34 +31,74 @@ describe('map usage', () => {
     document.body.removeChild(container);
   });
 
-  it('onFieldsChange works', () => {
-    const Test = createForm({
-      withRef: true,
-      onFieldsChange(props, fields) {
-        expect(Object.keys(fields).length).toBe(1);
-        const field = fields.normal;
-        expect(field.name).toBe('normal');
-        expect(field.value).toBe('3');
-      },
-      mapPropsToFields(props) {
-        return {
-          normal: {
-            value: props.formState.normal,
-          },
-        };
-      },
-    })(TestComponent);
-    component = ReactDOM.render(<Test formState={{ normal: '2' }}/>, container);
-    component = component.refs.wrappedComponent;
-    form = component.props.form;
-    expect(form.getFieldInstance('normal').value).toBe('2');
-    expect(form.getFieldValue('normal')).toBe('2');
-    expect(form.getFieldInstance('normal2').value).toBe('');
-    expect(form.getFieldValue('normal2')).toBe(undefined);
-    form.getFieldInstance('normal').value = '3';
-    Simulate.change(form.getFieldInstance('normal'));
-    expect(form.getFieldValue('normal')).toBe('3');
+
+  describe('onFieldsChange works', () => {
+    it('onFieldsChange works: fields', () => {
+      const Test = createForm({
+        withRef: true,
+        onFieldsChange(props, fields) {
+          expect(Object.keys(fields).length).toBe(1);
+          const field = fields.normal;
+          expect(field.name).toBe('normal');
+          expect(field.value).toBe('3');
+        },
+        mapPropsToFields(props) {
+          return {
+            normal: {
+              value: props.formState.normal,
+            },
+          };
+        },
+      })(TestComponent);
+      component = ReactDOM.render(<Test formState={{ normal: '2' }}/>, container);
+      component = component.refs.wrappedComponent;
+      form = component.props.form;
+      expect(form.getFieldInstance('normal').value).toBe('2');
+      expect(form.getFieldValue('normal')).toBe('2');
+      expect(form.getFieldInstance('normal2').value).toBe('');
+      expect(form.getFieldValue('normal2')).toBe(undefined);
+      form.getFieldInstance('normal').value = '3';
+      Simulate.change(form.getFieldInstance('normal'));
+      expect(form.getFieldValue('normal')).toBe('3');
+    });
+    it('onFieldsChange works: allFields', () => {
+      const Test = createForm({
+        withRef: true,
+        onFieldsChange(props, fields, allFields) {
+          if (fields.normal) return;
+          expect(Object.keys(allFields).length).toBe(2);
+          const fileChanged = fields.normal2;
+          expect(fileChanged.name).toBe('normal2');
+          expect(fileChanged.value).toBe('B');
+          const fieldNotChanged = allFields.normal;
+          expect(fieldNotChanged.name).toBe('normal');
+          expect(fieldNotChanged.value).toBe('3');
+        },
+        mapPropsToFields(props) {
+          return {
+            normal: {
+              value: props.formState.normal,
+            },
+            normal2: {
+              value: props.formState.normal2,
+            },
+          };
+        },
+      })(TestComponent);
+      component = ReactDOM.render(<Test formState={{ normal: '2', normal2: 'A' }}/>, container);
+      component = component.refs.wrappedComponent;
+      form = component.props.form;
+      expect(form.getFieldInstance('normal').value).toBe('2');
+      expect(form.getFieldValue('normal')).toBe('2');
+      expect(form.getFieldInstance('normal2').value).toBe('A');
+      expect(form.getFieldValue('normal2')).toBe('A');
+      form.getFieldInstance('normal').value = '3';
+      Simulate.change(form.getFieldInstance('normal'));
+      form.getFieldInstance('normal2').value = 'B';
+      Simulate.change(form.getFieldInstance('normal2'));
+    });
   });
+
 
   it('mapPropsToFields\'s return value will be merge to current fields', () => {
     const Test = createForm({


### PR DESCRIPTION
# Add full data argument for onFieldsChange and onValuesChange

```
- onFieldsChange(props, changeFields) {
+ onFieldsChange(props, changeFields, allFields) {
},
- onValuesChange(props, changeValues) {
+ onValuesChange(props, changeValues, allValues) {
},
```

Fix of https://github.com/react-component/form/issues/94 . Now when you use onFieldsChange() or onValuesChange() you have access to all the inputs of the form with values on it, not only the changed input. You can get it by access to the third parameter on each function.

This new feature can be checked by access http://localhost:8000/examples/nested-field.html if before you have run npm start:

![image](https://user-images.githubusercontent.com/2551046/31046635-681ed856-a5fc-11e7-9a59-72eb8ddf84d1.png)
