### PR TITLE
getFieldProps has side effect for array field

### DIFF
--- a/src/createFieldsStore.js
+++ b/src/createFieldsStore.js
@@ -192,7 +192,7 @@ class FieldsStore {
     ) {
       return getter(name);
     }
-    const isArrayValue = fullNames[0][name.length] === '[';
+    const isArrayValue = fullNames[fullNames.length - 1][name.length] === '[';
     const suffixNameStartIndex = isArrayValue ? name.length : name.length + 1;
     return fullNames
       .reduce(

--- a/tests/overview.spec.js
+++ b/tests/overview.spec.js
@@ -10,6 +10,7 @@ describe('getFieldProps\' behaviors', () => {
       class extends React.Component {
         render() {
           const { getFieldProps } = this.props.form;
+          getFieldProps('nested2'); // array value
           return (
             <form>
               <input {...getFieldProps('normal')} />


### PR DESCRIPTION
https://github.com/react-component/form/blob/db2316145713440736dd86eaa06fc17bc46e0f7a/src/createFieldsStore.js#L188-L195

`fullNames[0][name.length]` goes overflow and `isArrayValue` is always `true` when `fullNames[0] === name`.