### PR TITLE
fix: do not change the fieldsMeta when getFieldMeta

### DIFF
--- a/src/createFieldsStore.js
+++ b/src/createFieldsStore.js
@@ -95,8 +95,7 @@ class FieldsStore {
   }
 
   getFieldMeta(name) {
-    this.fieldsMeta[name] = this.fieldsMeta[name] || {};
-    return this.fieldsMeta[name];
+    return this.fieldsMeta[name] || {};
   }
 
   getValueFromFields(name, fields) {


### PR DESCRIPTION
when we try to use getFieldValue(key) to get the value ，it will call the getFieldMeta to get the value, then the new key will be storage which will cause the error(BG: `a` and `a.b` cannot be use in the same form) when the key`s is a nested value.