### PR TITLE
Break tree traversal on null value

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -22,7 +22,7 @@ export function flattenArray(arr) {
 export function treeTraverse(path = '', tree, isLeafNode, errorMessage, callback) {
   if (isLeafNode(path, tree)) {
     callback(path, tree);
-  } else if (tree === undefined) {
+  } else if (tree === undefined || tree === null) {
     return;
   } else if (Array.isArray(tree)) {
     tree.forEach((subTree, index) => treeTraverse(


### PR DESCRIPTION
`treeTraverse` crashes when there are `null` values in a nested object, since `Object.keys(null)` (see line 40) throws an error.

This PR breaks tree traversal on `null` values as well as `undefined` values. Line 25 could also be written as:
```javascript
export function treeTraverse(path = '', tree, isLeafNode, errorMessage, callback) {
  if (isLeafNode(path, tree)) {
    callback(path, tree);
  } else if (tree == null) {
    return;
  } else if (Array.isArray(tree)) {
...
```