### PR TITLE
Allow to use 'updateFields'

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,10 @@ Set fields initialValue by kv object. use for reset and initial display/value.
 
 Set fields by kv object. each field can contain errors and value member.
 
+### updateFields(obj: Object)
+
+Set fields by kv object. each field must be wrapped with `createFormField`.
+
 ### validateFields([fieldNames: String[]], [options: Object], callback: (errors, values) => void)
 
 Validate and get fields value by fieldNames.

--- a/src/createBaseForm.js
+++ b/src/createBaseForm.js
@@ -311,11 +311,6 @@ function createBaseForm(option = {}, mixins = []) {
         }
       },
 
-      // need this to save context for fieldsStore
-      updateFields(...args) {
-        this.fieldsStore.updateFields(...args);
-      },
-
       saveRef(name, _, component) {
         if (!component) {
           // after destroy, delete data

--- a/src/createBaseForm.js
+++ b/src/createBaseForm.js
@@ -311,6 +311,11 @@ function createBaseForm(option = {}, mixins = []) {
         }
       },
 
+      // need this to save context for fieldsStore
+      updateFields(...args) {
+        this.fieldsStore.updateFields(...args);
+      },
+
       saveRef(name, _, component) {
         if (!component) {
           // after destroy, delete data

--- a/src/createFieldsStore.js
+++ b/src/createFieldsStore.js
@@ -16,7 +16,7 @@ class FieldsStore {
     this.fieldsMeta = {};
   }
 
-  updateFields(fields) {
+  updateFields = (fields) => {
     this.fields = this.flattenFields(fields);
   }
 

--- a/src/createForm.js
+++ b/src/createForm.js
@@ -13,7 +13,7 @@ export const mixin = {
       getFieldProps: this.getFieldProps,
       getFieldsError: this.fieldsStore.getFieldsError,
       getFieldError: this.fieldsStore.getFieldError,
-      updateFields: this.updateFields,
+      updateFields: this.fieldsStore.updateFields,
       isFieldValidating: this.fieldsStore.isFieldValidating,
       isFieldsValidating: this.fieldsStore.isFieldsValidating,
       isFieldsTouched: this.fieldsStore.isFieldsTouched,

--- a/src/createForm.js
+++ b/src/createForm.js
@@ -13,6 +13,7 @@ export const mixin = {
       getFieldProps: this.getFieldProps,
       getFieldsError: this.fieldsStore.getFieldsError,
       getFieldError: this.fieldsStore.getFieldError,
+      updateFields: this.updateFields,
       isFieldValidating: this.fieldsStore.isFieldValidating,
       isFieldsValidating: this.fieldsStore.isFieldsValidating,
       isFieldsTouched: this.fieldsStore.isFieldsTouched,


### PR DESCRIPTION
**Why?**
I have a simple editable form, that can be stored in api:

```js
class MyForm extends Component {

    componentDidMount() {
        const { entity, form: { setFieldsValue } } = this.props;

        if (entity) {
            setFieldsValue(entity);
        }
    }

    render() {
        const { form: { getFieldDecorator, getFieldValue } } = this.props;

        return (
            <form>
                {getFieldDecorator('showInput')(<input type="checkbox" />)}
                {getFieldValue('showInput') && getFieldDecorator('input')(<input />)}
            </form>
        );
    }
}

export default Form.create()(MyForm);
````

When I want to edit this form with data from api like this:
```js
{
    showInput: true,
    input: 'value',
}
```

There isn't way to set them. According to this allowing to using `updateFields` will be very helpful. Thoughts?