### PR TITLE
Ignore type is hidden

### DIFF
--- a/src/createDOMForm.js
+++ b/src/createDOMForm.js
@@ -72,7 +72,7 @@ const mixin = {
             if (instance) {
               const node = ReactDOM.findDOMNode(instance);
               const top = node.getBoundingClientRect().top;
-              if (firstTop === undefined || firstTop > top) {
+              if (node.type !== 'hidden' && (firstTop === undefined || firstTop > top)) {
                 firstTop = top;
                 firstNode = node;
               }


### PR DESCRIPTION
If `input.type` is `hidden`, top is always `0`.