### PR TITLE
fix the field value will be an Object if 'getFieldDecorator' bind a string which include "." 

### DIFF
--- a/src/createFieldsStore.js
+++ b/src/createFieldsStore.js
@@ -181,7 +181,7 @@ class FieldsStore {
 
   getNestedFields(names, getter) {
     const fields = names || this.getValidFieldsName();
-    return fields.reduce((acc, f) => set(acc, f, getter(f)), {});
+    return fields.map(f => ({ [f]: getter(f) }));
   }
 
   getNestedField(name, getter) {


### PR DESCRIPTION
修复了当 'getFieldDecorator' 绑定包含“.”的字符串,  获取表单值的时候,
原本是字符串的值却变为对象的bug