### PR TITLE
Add better error message for unregisterred fields.

### DIFF
--- a/src/createFieldsStore.js
+++ b/src/createFieldsStore.js
@@ -33,7 +33,7 @@ class FieldsStore {
     return flattenFields(
       fields,
       path => validFieldsName.indexOf(path) >= 0,
-      'You cannot set field before registering it.'
+      'You cannot set a form field before rendering a field associated with the value.'
     );
   }
 


### PR DESCRIPTION
It was confusing to to me see:
'You cannot set field before registering it.'

I didn't understand that the problem was that a form element was not rendered yet.

I updated the message to say something about rendering the form element itself.