### PR TITLE
createForm support name props

### DIFF
--- a/src/createBaseForm.js
+++ b/src/createBaseForm.js
@@ -30,6 +30,7 @@ function createBaseForm(option = {}, mixins = []) {
     fieldMetaProp,
     fieldDataProp,
     formPropName = 'form',
+    name: formName,
     // @deprecated
     withRef,
   } = option;
@@ -217,7 +218,7 @@ function createBaseForm(option = {}, mixins = []) {
           ref: this.getCacheBind(name, `${name}__ref`, this.saveRef),
         };
         if (fieldNameProp) {
-          inputProps[fieldNameProp] = name;
+          inputProps[fieldNameProp] = formName ? `${formName}_${name}` : name;
         }
 
         const validateRules = normalizeValidateRules(validate, rules, validateTrigger);

--- a/tests/form.spec.js
+++ b/tests/form.spec.js
@@ -53,3 +53,26 @@ describe('resetFields', () => {
     expect(form.getFieldsValue(['normal'])).toEqual({ normal: '' });
   });
 });
+
+describe('form name', () => {
+  it('set id', () => {
+    const Test = createForm({
+      fieldNameProp: 'id',
+      name: 'test',
+    })(
+      class extends React.Component {
+        render() {
+          const { getFieldProps } = this.props.form;
+          return (
+            <input
+              {...getFieldProps('user')}
+            />
+          );
+        }
+      }
+    );
+    const wrapper = mount(<Test />);
+    const input = wrapper.find('input').instance();
+    expect(input.id).toBe('test_user');
+  });
+});


### PR DESCRIPTION
ref: https://github.com/ant-design/ant-design/issues/10218

`createForm` 用的 `fieldNameProp`， antd 里设置为 `id` 来转成组件的 id。这里就延续原本的 api 设计叫 `name` 了， `id` 的映射在 antd 里额外会开一个 pr。