### PR TITLE
fix: getFieldProps should use initialValue when value does not exist

### DIFF
--- a/src/createBaseForm.js
+++ b/src/createBaseForm.js
@@ -225,15 +225,20 @@ function createBaseForm(option = {}, mixins = []) {
           fieldMeta.initialValue = fieldOption.initialValue;
         }
 
+        const validateRules = normalizeValidateRules(validate, rules, validateTrigger);
+        const meta = {
+          ...fieldMeta,
+          ...fieldOption,
+          validate: validateRules,
+        };
         const inputProps = {
-          ...this.fieldsStore.getFieldValuePropValue(fieldOption),
+          ...this.fieldsStore.getFieldValuePropValue(meta),
           ref: this.getCacheBind(name, `${name}__ref`, this.saveRef),
         };
         if (fieldNameProp) {
           inputProps[fieldNameProp] = formName ? `${formName}_${name}` : name;
         }
 
-        const validateRules = normalizeValidateRules(validate, rules, validateTrigger);
         const validateTriggers = getValidateTriggers(validateRules);
         validateTriggers.forEach((action) => {
           if (inputProps[action]) return;
@@ -245,11 +250,6 @@ function createBaseForm(option = {}, mixins = []) {
           inputProps[trigger] = this.getCacheBind(name, trigger, this.onCollect);
         }
 
-        const meta = {
-          ...fieldMeta,
-          ...fieldOption,
-          validate: validateRules,
-        };
         this.fieldsStore.setFieldMeta(name, meta);
         if (fieldMetaProp) {
           inputProps[fieldMetaProp] = meta;

--- a/tests/createForm.spec.js
+++ b/tests/createForm.spec.js
@@ -305,3 +305,19 @@ describe('mapPropsToFields', () => {
     expect(form.getFieldValue('field2')).toBe(undefined);
   });
 });
+
+describe('getFieldProps', () => {
+  it('use initialValue when value does not exist', () => {
+    const Form = createForm({ withRef: true })(class extends React.Component {
+      render() {
+        return <div />;
+      }
+    });
+    const wrapper = mount(<Form />);
+    const form = wrapper.ref('wrappedComponent').props.form;
+    form.getFieldProps('field', {
+      initialValue: 'initial',
+    });
+    expect(form.getFieldProps('field').value).toBe('initial');
+  });
+});


### PR DESCRIPTION
This commit is trying to fix following issue: 

```javascript
props.getFieldProps('name', { initialValue: 'initial value' });
// or, equivalent
// props.setFieldsInitialValue({ name: 'initial value' });
// ...
console.log(props.getFieldValue('name')); // => output: initial value
console.log(props.getFieldProps('name').value); // => output: undefined
```

The issue here is, `fieldOption` in `getFieldProps` does not contain `initialValue` but `fieldMeta` has.
Thus, to get the value, better merge meta first.