### PR TITLE
add preserve on fieldOptions

### DIFF
--- a/src/createBaseForm.js
+++ b/src/createBaseForm.js
@@ -322,8 +322,10 @@ function createBaseForm(option = {}, mixins = []) {
             field: this.fieldsStore.getField(name),
             meta: this.fieldsStore.getFieldMeta(name),
           };
-          this.clearField(name);
-          delete this.domFields[name];
+          if (!this.fieldsStore.getFieldMeta(name).preserve) {
+            this.clearField(name);
+            delete this.domFields[name];
+          }
           return;
         }
         this.domFields[name] = true;


### PR DESCRIPTION
我的使用场景是这样，配置一个东西，`初始设置`之后就是`高级设置`，`高级设`置期间可以回退到`初始设置`，我现在用this.state.step去判断渲染`初始设置`还是`高级设置`。
然后问题就是，`高级设置`完成之后，拿不到初始化设置的结果。或者从高级设置回退上一步到`初始设置`之后，初始设置的值丢失。
解决方案：给getFieldDecorator的fieldoptions新增一个参数preserve，在unmount的时候判断是否清除信息。这样在恢复的时候，字段数据可以得到保留，字段数据的生命周期和form组件的声明周期一致