### PR TITLE
add preserve on fieldOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ This input's unique name.
 | option.validate[n].trigger | Event which is listened to validate. Set to falsy to only validate when call props.validateFields. | String|String[] | 'onChange' |
 | option.validate[n].rules | Validator rules. see: [async-validator](https://github.com/yiminghe/async-validator) | Object[] | - |
 | option.hidden | Ignore current field while validating or gettting fields | boolean | false |
+| option.preserve | Whether to preserve the value. That will remain the value when the field be unmounted and be mounted again | boolean | false |
 
 ##### Default value of `getValueFromEvent`
 

--- a/src/createBaseForm.js
+++ b/src/createBaseForm.js
@@ -52,6 +52,7 @@ function createBaseForm(option = {}, mixins = []) {
 
         this.renderFields = {};
         this.domFields = {};
+        this.preserveFields = {};
 
         // HACK: https://github.com/ant-design/ant-design/issues/6406
         ['getFieldsValue',
@@ -204,6 +205,12 @@ function createBaseForm(option = {}, mixins = []) {
           );
         }
 
+        if (!usersFieldOption.preserve){
+          delete this.preserveFields[name];
+        } else {
+          this.preserveFields[name] = true;
+        }
+        
         delete this.clearedFieldMetaCache[name];
 
         const fieldOption = {
@@ -317,13 +324,15 @@ function createBaseForm(option = {}, mixins = []) {
 
       saveRef(name, _, component) {
         if (!component) {
-          // after destroy, delete data
-          this.clearedFieldMetaCache[name] = {
-            field: this.fieldsStore.getField(name),
-            meta: this.fieldsStore.getFieldMeta(name),
-          };
-          this.clearField(name);
-          delete this.domFields[name];
+          if (!this.preserveFields[name]) {
+            // after destroy, delete data
+            this.clearedFieldMetaCache[name] = {
+              field: this.fieldsStore.getField(name),
+              meta: this.fieldsStore.getFieldMeta(name),
+            };
+            this.clearField(name);
+            delete this.domFields[name];
+          }
           return;
         }
         this.domFields[name] = true;
@@ -347,7 +356,7 @@ function createBaseForm(option = {}, mixins = []) {
       cleanUpUselessFields() {
         const fieldList = this.fieldsStore.getAllFieldsName();
         const removedList = fieldList.filter(field => (
-          !this.renderFields[field] && !this.domFields[field]
+          !this.renderFields[field] && !this.domFields[field] && !this.preserveFields[field]
         ));
         if (removedList.length) {
           removedList.forEach(this.clearField);

--- a/src/createBaseForm.js
+++ b/src/createBaseForm.js
@@ -52,7 +52,6 @@ function createBaseForm(option = {}, mixins = []) {
 
         this.renderFields = {};
         this.domFields = {};
-        this.preserveFields = {};
 
         // HACK: https://github.com/ant-design/ant-design/issues/6406
         ['getFieldsValue',
@@ -204,12 +203,6 @@ function createBaseForm(option = {}, mixins = []) {
             '`option.exclusive` of `getFieldProps`|`getFieldDecorator` had been remove.'
           );
         }
-
-        if (!usersFieldOption.preserve){
-          delete this.preserveFields[name];
-        } else {
-          this.preserveFields[name] = true;
-        }
         
         delete this.clearedFieldMetaCache[name];
 
@@ -324,11 +317,12 @@ function createBaseForm(option = {}, mixins = []) {
 
       saveRef(name, _, component) {
         if (!component) {
-          if (!this.preserveFields[name]) {
+          const fieldMeta = this.fieldsStore.getFieldMeta(name);
+          if (!fieldMeta.preserve) {
             // after destroy, delete data
             this.clearedFieldMetaCache[name] = {
               field: this.fieldsStore.getField(name),
-              meta: this.fieldsStore.getFieldMeta(name),
+              meta: fieldMeta,
             };
             this.clearField(name);
             delete this.domFields[name];
@@ -355,9 +349,10 @@ function createBaseForm(option = {}, mixins = []) {
 
       cleanUpUselessFields() {
         const fieldList = this.fieldsStore.getAllFieldsName();
-        const removedList = fieldList.filter(field => (
-          !this.renderFields[field] && !this.domFields[field] && !this.preserveFields[field]
-        ));
+        const removedList = fieldList.filter(field => {
+          const fieldMeta = this.fieldsStore.getFieldMeta(field);
+          return (!this.renderFields[field] && !this.domFields[field] && !fieldMeta.preserve);
+        });
         if (removedList.length) {
           removedList.forEach(this.clearField);
         }

--- a/src/createBaseForm.js
+++ b/src/createBaseForm.js
@@ -325,8 +325,8 @@ function createBaseForm(option = {}, mixins = []) {
               meta: fieldMeta,
             };
             this.clearField(name);
-            delete this.domFields[name];
           }
+          delete this.domFields[name];
           return;
         }
         this.domFields[name] = true;

--- a/src/createBaseForm.js
+++ b/src/createBaseForm.js
@@ -203,7 +203,7 @@ function createBaseForm(option = {}, mixins = []) {
             '`option.exclusive` of `getFieldProps`|`getFieldDecorator` had been remove.'
           );
         }
-        
+
         delete this.clearedFieldMetaCache[name];
 
         const fieldOption = {

--- a/tests/clean-field.spec.js
+++ b/tests/clean-field.spec.js
@@ -151,3 +151,99 @@ describe('Do not clean if field dom exist', () => {
     });
   });
 });
+
+describe('Don\'t clean field when has \'{ preserve: ture }\'', () => {
+  // Prepare
+  const Popup = ({ visible, children }) => {
+    if (!visible) return null;
+    return (
+      <div>
+        {children}
+      </div>
+    );
+  };
+
+  class Demo extends React.Component {
+    render() {
+      const { init, show } = this.props;
+      const { getFieldDecorator } = this.props.form;
+
+      let name;
+      let age;
+
+      if (init) {
+        name = (
+          <div>
+            name:
+            {getFieldDecorator('name', {
+              rules: [{ required: true }],
+            })(<input />)}
+          </div>
+        );
+      } else {
+        age = (
+          <div>
+            age:
+            {getFieldDecorator('age', {
+              rules: [{ required: true }],
+              preserve: true,
+            })(<input />)}
+          </div>
+        );
+      }
+
+      return (
+        <Popup visible={show}>
+          {name}
+          {age}
+        </Popup>
+      );
+    }
+  }
+
+  const FormDemo = createDOMForm({
+    withRef: true,
+  })(Demo);
+
+  class Test extends React.Component {
+    state = {
+      show: false,
+      init: false,
+    };
+
+    onClick = () => {
+      this.setState({ show: true });
+      this.setState({ init: true });
+    };
+
+    setRef = (demo) => {
+      this.demo = demo;
+    };
+
+    render() {
+      const { show, init } = this.state;
+      return (
+        <div>
+          <FormDemo ref={this.setRef} show={show} init={init} />
+          <button className="my-btn" onClick={this.onClick}>Show</button>
+        </div>
+      );
+    }
+  }
+
+  // Do the test
+  it('Don\'t remove when mount', done => {
+    const wrapper = mount(<Test />, { attachTo: document.body });
+    const form = wrapper.find('Demo').props().form;
+    form.validateFields((error) => {
+      expect(Object.keys(error)).toEqual(['age']);
+    });
+
+    wrapper.find('.my-btn').simulate('click');
+
+    form.validateFields((error) => {
+      expect(Object.keys(error)).toEqual(['age', 'name']);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
我的使用场景是这样，配置一个东西，初始设置之后就是高级设置，高级设置期间可以回退到初始设置，我现在用this.state.step去判断渲染初始设置还是高级设置。
然后问题就是，高级设置完成之后，拿不到初始化设置的结果。或者从高级设置回退上一步到初始设置之后，初始设置的值丢失。
解决方案：给getFieldDecorator的fieldoptions新增一个参数preserve，在unmount的时候判断是否清除信息。这样在恢复的时候，字段数据可以得到保留，字段数据的生命周期和form组件的声明周期一致