### PR TITLE
fix: 修复初次validateFields时， 自定义的validator里面有错误不会显示的bug

### DIFF
--- a/src/createBaseForm.js
+++ b/src/createBaseForm.js
@@ -529,7 +529,10 @@ function createBaseForm(option = {}, mixins = []) {
             options,
           }, callback);
         });
-        pending.catch((e) => e);
+        pending.catch((e) => {
+          console.error(e)
+          return e
+        });
         return pending;
       },
 


### PR DESCRIPTION
### 修复当使用者自定义 validator 中的组件没有触发 onChange 事件， 直接调用 validFields 时， validator 中的错误不会显示的 bug。

- 实例：https://codesandbox.io/s/38x7mk5r31
- 当一上来直接点击 submit 时，并不会出现报错的情况。