### PR TITLE
Create option to set the default validate trigger

### DIFF
--- a/src/createBaseForm.js
+++ b/src/createBaseForm.js
@@ -35,6 +35,7 @@ function createBaseForm(option = {}, mixins = []) {
     fieldDataProp,
     formPropName = 'form',
     name: formName,
+    defaultValidateTrigger = DEFAULT_TRIGGER,
     // @deprecated
     withRef,
   } = option;
@@ -218,7 +219,7 @@ function createBaseForm(option = {}, mixins = []) {
 
         const fieldOption = {
           name,
-          trigger: DEFAULT_TRIGGER,
+          trigger: defaultValidateTrigger,
           valuePropName: 'value',
           validate: [],
           ...usersFieldOption,


### PR DESCRIPTION
If you want something other than _onChange_ for the default validate trigger, it was a bit of a pain setting the validateTrigger on all the fields or overriding getFieldProps/getFieldDecorator. Now as an option to createForm we can set a different default validate trigger.