### PR TITLE
Fixed the problem that return value is an empty string when the form is a radio box

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -92,7 +92,7 @@ export function getValueFromEvent(e) {
     return e;
   }
   const { target } = e;
-  return target.type === 'checkbox' ? target.checked : target.value;
+  return target.type === 'checkbox' || target.type === 'radio' ? target.checked : target.value;
 }
 
 export function getErrorStrs(errors) {


### PR DESCRIPTION
Fixed the problem that return value is an empty string when the form is a radio box

`<FormItem label="radio">
    {
        getFieldDecorator('isOpen', {
            valuePropName: 'checked',
                initialValue: false
        })(<Radio>OPEN</Radio>)
    }
</FormItem>`