### PR TITLE
Passing current props as second params into mapPropsToFields and allo…

### DIFF
--- a/src/createBaseForm.js
+++ b/src/createBaseForm.js
@@ -87,7 +87,8 @@ function createBaseForm(option = {}, mixins = []) {
 
       componentWillReceiveProps(nextProps) {
         if (mapPropsToFields) {
-          this.fieldsStore.updateFields(mapPropsToFields(nextProps));
+          const newFields = mapPropsToFields(nextProps, this.props);
+          if (newFields) this.fieldsStore.updateFields(newFields);
         }
       },
 


### PR DESCRIPTION
A work around to implement [this](https://github.com/react-component/form/issues/334)

Allow passing current props into `mapPropsToFields` so user could control whether or not to update the fieldStore. 