### PR TITLE
Charnge error to waring and suppressWarning support

### DIFF
--- a/src/createBaseForm.js
+++ b/src/createBaseForm.js
@@ -635,9 +635,9 @@ function createBaseForm(option = {}, mixins = []) {
         });
         pending.catch(e => {
           // eslint-disable-next-line no-console
-          if (console.error && process.env.NODE_ENV !== 'production') {
+          if (console.warning && process.env.NODE_ENV !== 'production') {
             // eslint-disable-next-line no-console
-            console.error(e);
+            console.warning(e);
           }
           return e;
         });

--- a/src/createBaseForm.js
+++ b/src/createBaseForm.js
@@ -587,7 +587,6 @@ function createBaseForm(option = {}, mixins = []) {
       validateFields(ns, opt, cb) {
 		const { names, options } = getParams(ns, opt, cb);
         const pending = new Promise((resolve, reject) => {
-          const { names, options } = getParams(ns, opt, cb);
           let { callback } = getParams(ns, opt, cb);
           if (!callback || typeof callback === 'function') {
             const oldCb = callback;

--- a/src/createBaseForm.js
+++ b/src/createBaseForm.js
@@ -585,6 +585,7 @@ function createBaseForm(option = {}, mixins = []) {
       },
 
       validateFields(ns, opt, cb) {
+		const { names, options } = getParams(ns, opt, cb);
         const pending = new Promise((resolve, reject) => {
           const { names, options } = getParams(ns, opt, cb);
           let { callback } = getParams(ns, opt, cb);
@@ -635,9 +636,9 @@ function createBaseForm(option = {}, mixins = []) {
         });
         pending.catch(e => {
           // eslint-disable-next-line no-console
-          if (console.warning && process.env.NODE_ENV !== 'production') {
+          if (console.warn && process.env.NODE_ENV !== 'production' && !options.suppressWarning) {
             // eslint-disable-next-line no-console
-            console.warning(e);
+            console.warn(e);
           }
           return e;
         });


### PR DESCRIPTION
- `console.error` should not be used like this because it is hard to run tests with error logs. [async-validator](https://github.com/yiminghe/async-validator) is using warnings and `rc-form` should reflect the same strategy.

- Adding suppressWarning support as [async-validator](https://github.com/yiminghe/async-validator) to remove warnings when needed in tests suites.